### PR TITLE
Revert to ASP 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@
 ![DockerHub Version](https://img.shields.io/docker/v/uwcryo/asp-binder?sort=date)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/uw-cryo/asp-binder/master?urlpath=lab)
 
-### How to use
+This repository has the configuration for a Jupyter-ready docker image with ASP pre-installed. It is intended to create a standard environment for users to easily experiment with ASP code. Analysis examples live in separate repostories:
+
+| Topic | Binder Link | Repository | 
+| - | - | - | 
+| ASTER DEM | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/uw-cryo/asp-binder-demo/binder?urlpath=git-pull?repo=https://github.com/uw-cryo/asp-binder-demo%26amp%3Bbranch=master%26amp%3Burlpath=lab/tree/asp-binder-demo/example.ipynb/%3Fautodecode) | [Link](https://github.com/uw-cryo/asp-binder-demo/blob/master/example-aster_on_pangeo_binder_draft.ipynb) | 
+
+
+### How to update the image
 
 build with GitHub Actions simply by pushing to GitHub
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 # Install Ames stereo pipeline binary (~200Mb)
-#e.g. https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/3.0.0/StereoPipeline-3.0.0-2021-07-27-x86_64-Linux.tar.bz2
-DATE='2021-07-27'
-VERSION="3.0.0"
+#e.g. https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/2.7.0/StereoPipeline-2.7.0-2020-07-29-x86_64-Linux.tar.bz2
+# https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/3.0.0/StereoPipeline-3.0.0-2021-07-27-x86_64-Linux.tar.bz2
+DATE='2020-07-29'
+VERSION="2.7.0"
 NAME=StereoPipeline-$VERSION-$DATE-x86_64-Linux
-wget -q https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/3.0.0/$NAME.tar.bz2
+wget -q https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/$VERSION/$NAME.tar.bz2
 tar -xjf $NAME.tar.bz2
 mv $NAME /srv/StereoPipeline
 rm $NAME.tar.bz2


### PR DESCRIPTION
Example needs updating for 3.0, so can bump in future. This PR reverts to 2.7 cc @ShashankBice 

we should also add a link to that example (https://github.com/uw-cryo/asp-binder-demo) in the readme here