### PR TITLE
update link to indicate daily build

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -3,10 +3,12 @@
 # Install Ames stereo pipeline binary (~200Mb)
 #e.g. https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/2.7.0/StereoPipeline-2.7.0-2020-07-29-x86_64-Linux.tar.bz2
 # https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/3.0.0/StereoPipeline-3.0.0-2021-07-27-x86_64-Linux.tar.bz2
+# https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/2023-09-24-daily-build/StereoPipeline-3.4.0-alpha-2023-09-24-x86_64-Linux.tar.bz2
+# https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/3.3.0/StereoPipeline-3.3.0-Linux.tar.bz2
 DATE='2023-09-24'
 VERSION="3.4.0-alpha"
 NAME=StereoPipeline-$VERSION-$DATE-x86_64-Linux
-wget -q https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/$VERSION/$NAME.tar.bz2
+wget -q https://github.com/NeoGeographyToolkit/StereoPipeline/releases/download/$DATE-daily-build/$VERSION/$NAME.tar.bz2
 tar -xjf $NAME.tar.bz2
 mv $NAME /srv/StereoPipeline
 rm $NAME.tar.bz2


### PR DESCRIPTION
The format of the links has changed for both daily builds and stable releases, added commented versions of both, and updated the working command with the new daily-build link.